### PR TITLE
`% !BIB program  = biber`,build project more easy

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -1,0 +1,19 @@
+name: Build LaTeX document
+on: [push,pull_request]
+jobs:
+  build_latex:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v2
+
+      - name: Compile LaTeX document
+        uses: xu-cheng/latex-action@v2
+        with:
+          root_file: main.tex
+          latexmk_use_xelatex: true
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: PDF
+          path: main.pdf

--- a/config/preamble.tex
+++ b/config/preamble.tex
@@ -39,7 +39,7 @@
 \usepackage{xeCJK}
 \usepackage{fontspec}
 % \setCJKmainfont{SimSun} % 中文默认为宋体,小四在\documentclass处设置
-\setmainfont{Times New Roman} %英文默认为Times New Roman
+\setmainfont{TeX Gyre Termes} %英文默认为Times New Roman
 
 % LaTeX logo
 \usepackage{hologo}

--- a/config/preamble.tex
+++ b/config/preamble.tex
@@ -33,7 +33,8 @@
       breaklines,commentstyle=\color{white!50!black}\textit},
     title=\texttt{#1},listing only,breakable,
     left=6mm,right=6mm,top=2mm,bottom=2mm,listing file={#2}}
-
+% 三线表支持
+\usepackage{booktabs}
 
 % LaTeX logo
 \usepackage{hologo}

--- a/config/preamble.tex
+++ b/config/preamble.tex
@@ -38,7 +38,7 @@
 
 \usepackage{xeCJK}
 \usepackage{fontspec}
-\setCJKmainfont{SimSun} % 中文默认为宋体,小四在\documentclass处设置
+% \setCJKmainfont{SimSun} % 中文默认为宋体,小四在\documentclass处设置
 \setmainfont{Times New Roman} %英文默认为Times New Roman
 
 % LaTeX logo

--- a/config/preamble.tex
+++ b/config/preamble.tex
@@ -39,7 +39,8 @@
 \usepackage{xeCJK}
 \usepackage{fontspec}
 % \setCJKmainfont{SimSun} % 中文默认为宋体,小四在\documentclass处设置
-\setmainfont{texgyretermes-regular.otf} %英文默认为Times New Roman
-
+\setmainfont{texgyretermes-regular.otf} %和TNR很像的开源字体
+%\setmainfont{Times New Roman}  %英文默认为Times New Roman
+% Times new roman github actions可能没有,本地还是用Times New roman比较好
 % LaTeX logo
 \usepackage{hologo}

--- a/config/preamble.tex
+++ b/config/preamble.tex
@@ -36,5 +36,10 @@
 % 三线表支持
 \usepackage{booktabs}
 
+\usepackage{xeCJK}
+\usepackage{fontspec}
+\setCJKmainfont{SimSun} % 中文默认为宋体,小四在\documentclass处设置
+\setmainfont{Times New Roman} %英文默认为Times New Roman
+
 % LaTeX logo
 \usepackage{hologo}

--- a/config/preamble.tex
+++ b/config/preamble.tex
@@ -39,7 +39,7 @@
 \usepackage{xeCJK}
 \usepackage{fontspec}
 % \setCJKmainfont{SimSun} % 中文默认为宋体,小四在\documentclass处设置
-\setmainfont{TeX Gyre Termes} %英文默认为Times New Roman
+\setmainfont{texgyretermes-regular.otf} %英文默认为Times New Roman
 
 % LaTeX logo
 \usepackage{hologo}

--- a/main.tex
+++ b/main.tex
@@ -1,5 +1,6 @@
 % !Mode:: "TeX:UTF-8"
 % !TEX program  = xelatex
+% !BIB program  = biber
 \documentclass[AutoFakeBold,AutoFakeSlant,scheme=chinese,degree=bachelor,zihao=-4]{sustechthesis}
 % 1. AutoFakeBold 与 AutoFakeSlant 为伪粗与伪斜，如果本机上有相应粗体与斜体字体，请使用 xeCJK 宏包进行设置，例如：
 %   \setCJKmainfont[

--- a/main.tex
+++ b/main.tex
@@ -35,6 +35,7 @@
 
 \input{sections/examples/disclaimer.tex}
 \input{sections/examples/interface.tex}
+\input{sections/examples/details.tex}
 \input{sections/examples/figures.tex}
 \input{sections/examples/tutorial.tex}\clearpage
 \参考文献

--- a/sections/examples/details.tex
+++ b/sections/examples/details.tex
@@ -1,0 +1,25 @@
+% !Mode:: "TeX:UTF-8"
+% !TEX program  = xelatex
+
+\section{一些样例}
+
+\subsection{表格}
+
+\begin{table}[htb]
+% h-here,t-top,b-bottom,优先级依次下降
+    \begin{center}
+    % 居中
+        \caption{表格的标题应该放在上方}\label{table}
+        \begin{tabular}{lc} % 三线表不能有竖线,l-left,c-center,r-right
+            \toprule
+            %三线表-top 线
+            Example & Result \\
+            \midrule
+            %三线表-middle 线
+            Example1          & 0.25 \\
+            Example2          & 0.36 \\
+            \bottomrule
+            %三线表-底线
+        \end{tabular}
+    \end{center}
+\end{table}

--- a/sections/examples/figures.tex
+++ b/sections/examples/figures.tex
@@ -2,4 +2,5 @@
     \centering
     \includegraphics[width=.5\textwidth]{example-image-a}
     \caption{自带测试图片---Test image}\label{F:test-a}
+    % 图片的标题应该在下方
 \end{figure}

--- a/slides.tex
+++ b/slides.tex
@@ -1,5 +1,6 @@
 % !Mode:: "TeX:UTF-8"
 % !TEX program  = xelatex
+% !BIB program  = biber
 \documentclass{ctexbeamer}
   % Preamble
   \input{config/beamer.tex}

--- a/sustechthesis.cls
+++ b/sustechthesis.cls
@@ -53,9 +53,9 @@
 \RequirePackage{setspace}
 \RequirePackage{graphicx}
 \RequirePackage{caption}
-  \renewcommand{\captionfont}{\bfseries\songti\zihao{5}} %表题用五号宋体加黑
+  \renewcommand{\captionfont}{\bfseries\songti\zihao{5}} %表题,图题用五号宋体加黑
   \DeclareCaptionLabelSeparator{enspace}{\enspace}
-  \captionsetup[table]{labelsep=enspace} %表序与表题之间没有标点
+  \captionsetup{labelsep=enspace} %表序表题,图序图题之间没有标点,而是一个空格
 \RequirePackage{ctex}
   % 字号汉化设置
   \newcommand{\初号}{\zihao {0}}

--- a/sustechthesis.cls
+++ b/sustechthesis.cls
@@ -53,7 +53,9 @@
 \RequirePackage{setspace}
 \RequirePackage{graphicx}
 \RequirePackage{caption}
-  \renewcommand{\captionfont}{\heiti\zihao{5}}
+  \renewcommand{\captionfont}{\bfseries\songti\zihao{5}} %表题用五号宋体加黑
+  \DeclareCaptionLabelSeparator{enspace}{\enspace}
+  \captionsetup[table]{labelsep=enspace} %表序与表题之间没有标点
 \RequirePackage{ctex}
   % 字号汉化设置
   \newcommand{\初号}{\zihao {0}}
@@ -143,6 +145,12 @@
 
 % 目录
 \newcommand{\目录}{\setcounter{page}{1}\tableofcontents}
+\RequirePackage{fancyhdr}
+  \pagestyle{fancy}
+    \lhead{}\chead{}\rhead{}\lfoot{}\rfoot{}
+    \cfoot{\thepage} %除了页脚页码之外,什么也没有
+    \renewcommand{\headrulewidth}{0pt} %改为0pt即可去掉页眉下面的横线
+    \renewcommand{\footrulewidth}{0pt} %改为0pt即可去掉页脚上面的横线
 % 设置标题页
 \newcommand\下划线[2][6em]{\hskip1pt\underline{\hb@xt@ #1{\hss#2\hss}}\hskip3pt}
 \newcommand\中文标题页{%
@@ -275,7 +283,7 @@
       \noindent\三号 [\textbf{ABSTRACT}]:
       \四号}%
   {\vfill
-      \noindent\三号 [\textbf{Keywords}]:
+      \noindent\三号 [\textbf{Key words}]:
       \四号 \args[1]
     \end{spacing}
     \vfill\clearpage}

--- a/sustechthesis.cls
+++ b/sustechthesis.cls
@@ -55,7 +55,8 @@
 \RequirePackage{caption}
   \renewcommand{\captionfont}{\bfseries\songti\zihao{5}} %表题,图题用五号宋体加黑
   \DeclareCaptionLabelSeparator{enspace}{\enspace}
-  \captionsetup{labelsep=enspace} %表序表题,图序图题之间没有标点,而是一个空格
+  \captionsetup{labelsep=enspace} %表序表题之间没有标点,而是一个空格
+  \captionsetup[figures]{labelsep=enspace} %图序图题之间没有标点,而是一个空格
 \RequirePackage{ctex}
   % 字号汉化设置
   \newcommand{\初号}{\zihao {0}}
@@ -147,8 +148,8 @@
 \newcommand{\目录}{\setcounter{page}{1}\tableofcontents}
 \RequirePackage{fancyhdr}
   \pagestyle{fancy}
-    \lhead{}\chead{}\rhead{}\lfoot{}\rfoot{}
-    \cfoot{\thepage} %除了页脚页码之外,什么也没有
+    \lhead{}\chead{}\rhead{}\lfoot{}\rfoot{}%除了页脚页码之外,什么也没有
+    \cfoot{\五号\thepage} %页脚居中、阿拉伯数字（五号新罗马体）连续编码
     \renewcommand{\headrulewidth}{0pt} %改为0pt即可去掉页眉下面的横线
     \renewcommand{\footrulewidth}{0pt} %改为0pt即可去掉页脚上面的横线
 % 设置标题页

--- a/sustechthesis.cls
+++ b/sustechthesis.cls
@@ -55,7 +55,7 @@
 \RequirePackage{caption}
   \renewcommand{\captionfont}{\bfseries\songti\zihao{5}} %表题,图题用五号宋体加黑
   \DeclareCaptionLabelSeparator{enspace}{\enspace}
-  \captionsetup{labelsep=enspace} %表序表题之间没有标点,而是一个空格
+  \captionsetup[table]{labelsep=enspace} %表序表题之间没有标点,而是一个空格
   \captionsetup[figures]{labelsep=enspace} %图序图题之间没有标点,而是一个空格
 \RequirePackage{ctex}
   % 字号汉化设置


### PR DESCRIPTION
latex-workshop里默认的`build latex project`会读取文件里的信息,

没有这一行的话只会执行`xelatex`,添加之后才会执行biber,

这样pdf文件中参考文献部分就不会是空白了.

PS:当然,添加之后的默认步骤变成了`xelatex -> biber -> xelatex ->xelatex`-变成了四步,比原来慢了很多.