### PR TITLE
modify Makefile to put all build files in 'output' dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 ## 参考文件
 format/*
 
+## Build Dir
+output/
+
+## Jetbrains IDEs
+.idea/
+
 ## Core latex/pdflatex auxiliary files:
 *.aux
 *.lof
@@ -24,8 +30,6 @@ format/*
 # *.eps
 # *.pdf
 
-## Generated if empty string is given at "Please type another file name for output:"
-*.pdf
 
 ## Bibliography auxiliary files (bibtex/biblatex/biber):
 *.bbl

--- a/Makefile
+++ b/Makefile
@@ -6,35 +6,39 @@ SLIDE  = slides
 
 # make deletion work on Windows
 ifdef SystemRoot
-	RM = del /Q
+	RMRF = rd /s /q
+	RM = del
+	CP = copy
+	SEP = \\
 else
+	RMRF = rm -rf
 	RM = rm -f
+	CP = cp
+	SEP = /
 endif
 
-.PHONY: all clean cleanall thesis slide viewthesis viewslide FORCE_MAKE
-
-thesis: $(THESIS).pdf
-slide: $(SLIDE).pdf
-
+.PHONY: all
 all: thesis
 
-$(THESIS).pdf: FORCE_MAKE
-	$(LATEXMK) $(THESIS)
+.PHONY: thesis
+thesis:
+	$(LATEXMK) -outdir=$(OUTDIR)/thesis -quiet -jobname=thesis $(THESIS)
+	-@mkdir $(OUTDIR)$(SEP)artifact
+	-@$(CP) $(OUTDIR)$(SEP)thesis$(SEP)thesis.pdf $(OUTDIR)$(SEP)artifact
 
-$(SLIDE).pdf: FORCE_MAKE
-	$(LATEXMK) $(SLIDE)
+.PHONY: slide
+slides:
+	$(LATEXMK) -outdir=$(OUTDIR)/slide -quiet -jobname=slide $(SLIDE)
+	-@mkdir $(OUTDIR)$(SEP)artifact
+	-@$(CP) $(OUTDIR)$(SEP)slides$(SEP)slides.pdf $(OUTDIR)$(SEP)artifact
 
+.PHONY: clean
+clean:
+	-@$(RMRF) output
+
+.PHONY: viewthesis
 viewthesis: thesis
-	$(LATEXMK) -pv $(THESIS)
+	$(LATEXMK) -outdir=$(OUTDIR)/thesis -jobname=thesis -pv $(THESIS)
 
 viewslide: slide
-	$(LATEXMK) -pv $(SLIDE)
-
-clean:
-	$(LATEXMK) -c $(THESIS)
-	$(LATEXMK) -c $(SLIDE)
-	-@$(RM) -rf *~
-
-cleanall: clean
-	-@$(RM) $(THESIS).pdf
-	-@$(RM) $(SLIDE).pdf
+	$(LATEXMK) -outdir=$(OUTDIR)/slide -jobname=slide -pv $(SLIDE)


### PR DESCRIPTION
Previously the `make thesis` and `make slide` generate build files under project root.

Now the `make thesis` and `make slide` commands will output files in the `output/` dir, which makes the project structure well organized and easy to manage.

Also note that I remove the `*.pdf` from `.gitignore`.