### PR TITLE
Fix empty line when subtitle is not set

### DIFF
--- a/sustechthesis.cls
+++ b/sustechthesis.cls
@@ -337,9 +337,6 @@
         }{% not empty
           \sustech@info@item[5em]{}[9cm]{\副标题@中}\\[9pt]
         }%
-      \end{tabular}
-      \vfill
-      \begin{tabular}{lc}
         \sustech@info@item[5em]{姓名：}[9cm]{\姓名@中}\\[9pt]
         \sustech@info@item[5em]{学号：}[9cm]{\学号@中}\\[9pt]
         \sustech@info@item*[5em]{系别：}[9cm]{\系别@中}\\[9pt]
@@ -375,9 +372,6 @@
         }{% not empty
           \sustech@info@item{}[9cm]{\副标题@英}\\[9pt]
         }%
-      \end{tabular}
-      \vfill
-      \begin{tabular}{lc}
         \sustech@info@item{Student Name:}[9cm]{\姓名@英}\\[9pt]
         \sustech@info@item{Student ID:}[9cm]{\学号@英}\\[9pt]
         \sustech@info@item*{Department:}[9cm]{\系别@英}\\[9pt]


### PR DESCRIPTION
当论文中不需要副标题时，如设置`副标题 = {{}, {}}`的情况，此时用overleaf/sharelatex渲染在论文封面会出现空白的一行，影响论文版面。

![1f9a183bea498aff6c540f0dc5e53df](https://github.com/iydon/sustechthesis/assets/82224175/9cd58045-fd37-4a83-8e12-a178192d42fb)

该PR修复了这一问题，并保证文章存在副标题时也能正常渲染。

![image](https://github.com/iydon/sustechthesis/assets/82224175/9f26f09f-114e-4984-a90b-52db0c374265)

