### PR TITLE
修复英文环境下的若干Bug，添加英文示例

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,6 @@ TSWLatexianTemp*
 
 # generated if using elsarticle.cls
 *.spl
+
+# mac
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Southern University of Science and Technology Thesis Template LaTeX Template for
 * `config/preamble.tex`: 导言区，导入宏包，宏定义。
 * `config/info.tex`: 论文信息，例如：标题，作者，等。
 * `main.tex`: 主文档，编排章节顺序。
+* `main_english.tex`: 英文主文档，编排章节顺序。
 * `slides.tex`: beamer 幻灯片模版。
 
 

--- a/config/preamble.tex
+++ b/config/preamble.tex
@@ -6,8 +6,13 @@
   \newcommand{\dd}{\mathrm{d}}
   \newcommand{\RR}{\mathbb{R}}
 % 参考文献
-\usepackage[style=gb7714-2015,gbpunctin=false]{biblatex}
+\if sustech@chinese
+  \usepackage[style=gb7714-2015,gbpunctin=false]{biblatex}
   \addbibresource{ref.bib}
+\else
+  \usepackage[style=trad-abbrv, firstinits=true]{biblatex}
+  \addbibresource{ref.bib}
+\fi
 % 无意义文本
 \usepackage{zhlipsum,lipsum}
 % 列表环境设置

--- a/main_english.tex
+++ b/main_english.tex
@@ -1,7 +1,7 @@
 % !Mode:: "TeX:UTF-8"
 % !TEX program  = xelatex
 % !BIB program  = biber
-\documentclass[AutoFakeBold,AutoFakeSlant,language=chinese,degree=bachelor]{sustechthesis}
+\documentclass[AutoFakeBold,AutoFakeSlant,language=english,degree=bachelor]{sustechthesis}
 % 1. AutoFakeBold 与 AutoFakeSlant 为伪粗与伪斜，如果本机上有相应粗体与斜体字体，请使用 xeCJK 宏包进行设置，例如：
 %   \setCJKmainfont[
 %     UprightFont = * Light,
@@ -16,7 +16,7 @@
 %
 % 4. sustechthesis.cls 文类主要参考自去年完成使命的 sustechthesis.tex，在这一年的时间，作者的 TeX 风格与常用宏包发生许多变化，因为之前的思想为仅提供必要的格式修改相关代码，所以转换为文类形式所进行的修改较少，而近期的风格与常用宏包均体现在以下的例子文件中。
 %
-% 5. 示例文件均放置于相应目录的 examples 文件夹下，构建自己论文时可暂时保留，用以检索接口与使用方法。
+% 5. 英文示例文件均放置于相应目录的 examples_english 文件夹下，构建自己论文时可暂时保留，用以检索接口与使用方法。
 %
 % 6. 英文目录需要居中可以使用：\renewcommand{\contentsname}{\centerline{Content}}
 %
@@ -26,27 +26,27 @@
 \input{config/info.tex} % 论文信息
 \begin{document}
 
-\中文标题页\英文标题页
+\英文标题页
 
-\中文诚信承诺书
+\英文诚信承诺书
 
 \前序格式化
 \摘要标题
-\input{sections/examples/abstract.tex} % 论文摘要
+\input{sections/examples_english/abstract.tex} % 论文摘要
 
 \目录\cleardoublepage % 目录及换页
 
 \正文格式化
-\input{sections/examples/disclaimer.tex}
-\input{sections/examples/interface.tex}
-\input{sections/examples/details.tex}
-\input{sections/examples/figures.tex}
-\input{sections/examples/tutorial.tex}\cleardoublepage
+\input{sections/examples_english/disclaimer.tex}
+\input{sections/examples_english/interface.tex}
+\input{sections/examples_english/details.tex}
+\input{sections/examples_english/figures.tex}
+\input{sections/examples_english/tutorial.tex}\cleardoublepage
 
 \参考文献
   \printbibliography[heading=none]\cleardoublepage
 \附录
-  \input{sections/examples/appendix.tex}\cleardoublepage
+  \input{sections/examples_english/appendix.tex}\cleardoublepage
 \致谢
-  \input{sections/examples/thanks.tex}
+  \input{sections/examples_english/thanks.tex}
 \end{document}

--- a/sections/examples_english/abstract.tex
+++ b/sections/examples_english/abstract.tex
@@ -1,0 +1,15 @@
+% !Mode:: "TeX:UTF-8"
+% !TEX program  = xelatex
+
+\begin{英文摘要}{Keyword A; Keyword B; Keyword C}
+  Most of the thesis templates I have encountered are in the form of document classes, with a few as macro packages. Moreover, these templates often include various examples (except for those maintained frequently), resulting in template files cluttered with content unrelated to formatting. The codebase is massive, documentation is lacking, and modifications are difficult. When issues arise, one often needs to delve into the source code of the macro package or document class. Therefore, adhering to the principle of providing only the most basic necessary features, I refactored the previously written \TeX\ template. Since this is the second year of using this template, I cannot guarantee that the template interface will remain unchanged in the future—everything is subject to the documentation. After all, the university is in its early stages of development, and all documents are gradually being refined. In previous years, the school's logo and name underwent changes, and the thesis formatting also saw significant revisions. However, I can assure you that the template's interfaces are all in Chinese\footnote{Leveraging \hologo{XeLaTeX} features enhances recognizability while avoiding strict adherence to English naming conventions. Of course, this approach has some drawbacks, which I won’t elaborate on here.}, and it will be updated at least until 2021, the year of my graduation.
+  
+  A template cannot be expected to work perfectly forever. On one hand, the university's standards and regulations are constantly evolving; on the other hand, \hologo{LaTeX} macro packages are also changing. Popular macro packages from earlier years may become "obsolete" a few years later. Therefore, your usage and feedback are the driving forces behind my continuous updates. I sincerely welcome any suggestions and advice.
+  \end{英文摘要}
+  
+  \begin{中文摘要}{关键词甲；关键词乙；关键词丙}
+    笔者见到的毕业论文模板，大多是以文类的形式，少部分以宏包的形式，并且在模板中大多掺杂着各式各样的例子（除了维护频率高的模板），导致模板文件使用了大部分与形式格式不相关的内容，代码量巨大文档欠缺且不容易修改，出现问题需要查看宏包或者文类的源代码。于是，秉着仅提供实现最基本要求的理念，重构了之前所写的 \TeX\ 形式。由于第二年使用该模板，所以设计出的模板接口不能保证以后不发生重大变动，一切以文档为主。毕竟学校在发展初期，各类文件都在日渐完善，前几年时，学校标志及名称还发生变化，同时毕业论文的样式也发生了重大变化。但是可以保证的是，模板提供的接口均为中文形式\footnote{使用 \hologo{XeLaTeX} 特性，一方面增加辨识度，另一方面不拘泥于英文命名的规则。当然此举也有些许弊端，在此就不过多展开。}，并且至少更新到 2021 年，也就是笔者毕业。模板这种东西不能保证一劳永逸，一方面学校的标准制度都在发生着改变，另一方面 \hologo{LaTeX} 的宏包也在发生着改变，早先流行的宏包可能几年后就被“淘汰”掉。因此，您的使用与反馈是我不断更新的动力，希望各位不吝赐教。
+  \end{中文摘要}
+
+  \cleardoublepage
+

--- a/sections/examples_english/appendix.tex
+++ b/sections/examples_english/appendix.tex
@@ -1,0 +1,4 @@
+% !Mode:: "TeX:UTF-8"
+% !TEX program  = xelatex
+\section*{Data Retrieval Function}\label{A:data}
+\Python{utils.py}{code/examples/utils.py}

--- a/sections/examples_english/details.tex
+++ b/sections/examples_english/details.tex
@@ -1,0 +1,59 @@
+% !Mode:: "TeX:UTF-8"
+% !TEX program  = xelatex
+
+\section{Some Examples}
+
+\subsection{Tables}
+
+Tables and figures can be cited directly via \verbbox{\ref{<key>}}, for example Tab.~\ref{table2}, Fig.~\ref{F:test-a}, and Fig.~\ref{F:test-b-sub-b}.
+
+\begin{table}[htb]
+% h-here, t-top, b-bottom (priority decreases in order)
+    % Centered (the template already sets table floats to be centered)
+    \centering
+    \caption{Table titles should be placed at the top}
+    \label{table}
+    \begin{tabular}{lc} % Three-line tables should not have vertical lines; l-left, c-center, r-right
+        \toprule
+        % Three-line table - top rule
+        Example & Result \\
+        \midrule
+        % Three-line table - middle rule
+        Example1          & 0.25 \\
+        Example2          & 0.36 \\
+        \bottomrule
+        % Three-line table - bottom rule
+    \end{tabular}
+\end{table}
+
+\begin{table}[htb]
+    \centering
+    \caption{Table title with notes}
+    \label{table2}
+    \begin{threeparttable}
+        \setlength{\tabcolsep}{0.6cm}{ % Adjust table width
+                \begin{tabular}{lc} % Three-line tables should not have vertical lines; l-left, c-center, r-right
+                    \toprule
+                    % Three-line table - top rule
+                    Example & Result \\
+                    \midrule
+                    % Three-line table - middle rule
+                    Example1          & 0.25\tnote{1} \\
+                    Example2          & 0.36 \\
+                    \bottomrule
+                    % Three-line table - bottom rule
+                \end{tabular}
+        }
+        \begin{tablenotes}
+            \item[1] Data source: Southern University of Science and Technology \LaTeX template % Add table note for data source
+        \end{tablenotes}
+    \end{threeparttable}
+\end{table}
+
+\begin{proof}
+    This is a proof written in English.
+\end{proof}
+
+\subsection{References}
+
+References are usually cited using the \verbbox{\cite{<key>}} command, as shown here: \cite{Nicholas1998Handbook}. To cite authors, use \verbbox{\citeauthor{<key>}}, for example: "\citeauthor{goossens1994latex}."

--- a/sections/examples_english/disclaimer.tex
+++ b/sections/examples_english/disclaimer.tex
@@ -1,0 +1,8 @@
+% !Mode:: "TeX:UTF-8"
+% !TEX program  = xelatex
+\section{Disclaimer}
+\begin{enumerate}[label={\alph*)}]
+    \item This template is released under the \LaTeX\ Project Public License. Please read the license terms carefully before use.
+    \item The Academic Affairs Office of Southern University of Science and Technology (SUSTech) only provides thesis writing guidelines and does not offer an official template, nor does it authorize any third-party template as official. Therefore, this template is merely a reference implementation of the writing guidelines and does not guarantee that format reviewers will raise no objections. The author of this template shall not be held responsible for any format-related issues arising from its use during thesis review.
+    \item Any individuals or organizations modifying or extending this template to create new specialized templates must strictly comply with the \LaTeX\ Project Public License. The author of this template shall not be liable for any disputes or conflicts resulting from violations of the license.
+\end{enumerate}

--- a/sections/examples_english/figures.tex
+++ b/sections/examples_english/figures.tex
@@ -1,0 +1,21 @@
+\begin{figure}[htb]
+    \centering
+    \includegraphics[width=.5\textwidth]{example-image-a}
+    \caption{Built-in test image}\label{F:test-a}
+    % Figure captions should be placed below the image
+\end{figure}
+
+\begin{figure}[htb]
+    \centering
+    \begin{subfigure}[t]{.45\linewidth}
+        \centering
+        \includegraphics[width=1\textwidth]{example-image-a}
+        \caption{Subfigure - Built-in test image}\label{F:test-b-sub-a}
+    \end{subfigure}
+    \begin{subfigure}[t]{.45\linewidth}
+        \centering
+        \includegraphics[width=1\textwidth]{example-image-a}
+        \caption{Subfigure - Built-in test image}\label{F:test-b-sub-b}
+    \end{subfigure}
+    \caption{Built-in test image}\label{F:test-b}
+\end{figure}

--- a/sections/examples_english/interface.tex
+++ b/sections/examples_english/interface.tex
@@ -1,0 +1,31 @@
+% !Mode:: "TeX:UTF-8"
+% !TEX program  = xelatex
+\section{Document Class Interface}
+The document class interface uses Chinese naming conventions, with names reflecting their literal meanings. For any questions, please submit \href{https://github.com/Iydon/sustechthesis/issues}{Issues} on GitHub.
+
+\subsection{Sinified Font Size Interface}
+This interface primarily utilizes the \texttt{ctex} package.
+
+\verbbox{\初号}, \verbbox{\小初}, \verbbox{\一号}, \verbbox{\小一}, \verbbox{\二号}, \verbbox{\小二}, \verbbox{\三号}, \verbbox{\小三}, \verbbox{\四号}, \verbbox{\小四}, \verbbox{\五号}, \verbbox{\小五}, \verbbox{\六号}, \verbbox{\小六}, \verbbox{\七号}, \verbbox{\八号}.
+
+\subsection{Sinified Font Family Interface}
+Some fonts might be unavailable on local systems, which may prevent certain font styles from working.
+
+\verbbox{\宋体}, \verbbox{\黑体}, \verbbox{\仿宋}, \verbbox{\楷书}, \verbbox{\隶书}, \verbbox{\幼圆}, \verbbox{\雅黑}, \verbbox{\苹方}.
+
+\subsection{Font Style Interface}
+
+For body text, it's recommended to use \verb|\textbf{}| and \verb|\textit{}| for \textbf{bold} and \textit{italic} styles respectively.
+
+\verbbox{\粗体}, \verbbox{\斜体}.
+
+\subsection{Formatting-related Interface}
+\subsubsection{Commands}
+Refer to previous examples. During early thesis writing, you may comment out unnecessary elements like title pages to speed up compilation.
+
+\verbbox{\设置信息}, \verbbox{\目录}, \verbbox{\下划线}, \verbbox{\中文标题页}, \verbbox{\英文标题页}, \verbbox{\中文诚信承诺书}, \verbbox{\英文诚信承诺书}, \verbbox{\摘要标题}, \verbbox{\参考文献}, \verbbox{\附录}, \verbbox{\致谢}.
+
+\subsubsection{Environments}
+All abstract environments require one parameter for keywords: \verb|\begin{}{}...\end{}|.
+
+\verbbox{中文摘要}, \verbbox{英文摘要}.

--- a/sections/examples_english/thanks.tex
+++ b/sections/examples_english/thanks.tex
@@ -1,0 +1,14 @@
+% !Mode:: "TeX:UTF-8"
+% !TEX program  = xelatex
+\sustechthesis\ current version is \version. The \LaTeX\ thesis template project has been developed over two years since its inception. We would like to thank the developers who contributed code to this project:
+\begin{itemize}
+    \item Yudong Liang (Southern University of Science and Technology, Class of 2017 undergraduate);
+    \item Zhijiong Zhang (Southern University of Science and Technology, Class of 2017 undergraduate).
+\end{itemize}
+as well as the users who adopted this project and provided valuable suggestions for improvement:
+\begin{itemize}
+    \item Weiyan Li (Southern University of Science and Technology, Class of 2015 undergraduate);
+    \item Ercong Li (Southern University of Science and Technology, Class of 2015 undergraduate).
+\end{itemize}
+
+Additionally, please note that the current maintainer is not from the Computer Science Department, which may lead to potential misuse of licenses or other technical aspects. If you identify any issues with this template, please submit them via \href{https://github.com/Iydon/sustechthesis/issues}{GitHub Issues}. Contributions to the codebase are also most welcome!

--- a/sections/examples_english/tutorial.tex
+++ b/sections/examples_english/tutorial.tex
@@ -1,0 +1,4 @@
+% !Mode:: "TeX:UTF-8"
+% !TEX program  = xelatex
+\section{Getting Started with \LaTeX}
+Please refer to the \href{https://tex.readthedocs.io/zh_CN/latest/}{online documentation}, which includes learning resources and study paths. You're welcome to submit \href{https://github.com/Iydon/tex/issues}{Issues} on GitHub.

--- a/sustechthesis.cls
+++ b/sustechthesis.cls
@@ -142,9 +142,9 @@
     \captionsetup[table]{labelsep=enspace} %表序表题之间没有标点,而是一个空格,默认前缀为表
     \captionsetup[figure]{labelsep=enspace} %图序图题之间没有标点,而是一个空格，默认前缀为图
   \else
-      \renewcommand{\captionfont}{\五号} %表题,图题用五号宋体加黑
-      \captionsetup[table]{labelsep=period, labelfont=bf}
-      \captionsetup[figure]{labelsep=period, labelfont=bf}
+      \renewcommand{\captionfont}{\五号} %表题,图题用五号
+      \captionsetup[table]{labelsep=period, labelfont=bf} %图序图题之间用.分割， 加粗
+      \captionsetup[figure]{labelsep=period, labelfont=bf} %图序图题之间用.分割， 加粗
     \ctexset{figurename = {Figure}, tablename  = {Table},}%
   \fi
 

--- a/sustechthesis.cls
+++ b/sustechthesis.cls
@@ -10,7 +10,7 @@
 %% 
 \NeedsTeXFormat{LaTeX2e}[1999/12/01]
 \ProvidesClass{sustechthesis}
-  [2024/02/28 v1.3.7 SUSTech Thesis Template]
+  [2025/04/26 v1.3.7 SUSTech Thesis Template]
 \RequirePackage{ifxetex,ifluatex,ifthen}
   \ifthenelse{\boolean{xetex}\OR\boolean{luatex}}{}{
     \ClassError{sustechthesis}{You Should Use XeLaTeX or LuaLaTeX To Compile.}}

--- a/sustechthesis.cls
+++ b/sustechthesis.cls
@@ -10,14 +10,14 @@
 %% 
 \NeedsTeXFormat{LaTeX2e}[1999/12/01]
 \ProvidesClass{sustechthesis}
-  [2024/02/28 v1.3.6 SUSTech Thesis Template]
+  [2024/02/28 v1.3.7 SUSTech Thesis Template]
 \RequirePackage{ifxetex,ifluatex,ifthen}
   \ifthenelse{\boolean{xetex}\OR\boolean{luatex}}{}{
     \ClassError{sustechthesis}{You Should Use XeLaTeX or LuaLaTeX To Compile.}}
 
 \hyphenation{SUSTech-Thesis}
 \newcommand{\sustechthesis}{SUSTechThesis}
-\newcommand{\version}{1.3.5}
+\newcommand{\version}{1.3.7}
 \RequirePackage{kvoptions}
 \SetupKeyvalOptions{
   family=sustech,
@@ -133,29 +133,20 @@
     },
   }
 \RequirePackage{caption}
-  \renewcommand{\captionfont}{\bfseries\songti\五号} %表题,图题用五号宋体加黑
   \DeclareCaptionLabelSeparator{enspace}{\enspace}
   \DeclareCaptionLabelFormat{rightBracket}{#2)}
-  \captionsetup[table]{labelsep=enspace} %表序表题之间没有标点,而是一个空格,默认前缀为表
-  \captionsetup[figure]{labelsep=enspace} %图序图题之间没有标点,而是一个空格，默认前缀为图
   \ifsustech@chinese
-    \ctexset{
-      figurename = {图},
-      tablename  = {表},
-      listfigurename = {插图},
-      listtablename = {表格},
-      proofname = {证明},
-    }%
+    \renewcommand{\captionfont}{\bfseries\songti\五号} %表题,图题用五号宋体加黑
+    \ctexset{figurename = {图}, tablename  = {表},}%
+    \captionsetup[subfigure]{labelformat=rightBracket, labelsep=enspace}% 子图a,b,c外没有括号
+    \captionsetup[table]{labelsep=enspace} %表序表题之间没有标点,而是一个空格,默认前缀为表
+    \captionsetup[figure]{labelsep=enspace} %图序图题之间没有标点,而是一个空格，默认前缀为图
   \else
-    \ctexset{
-      figurename = {Figure},
-      tablename  = {Table},
-      listfigurename = {List of Figures},
-      listtablename = {List of Tables},
-      proofname = {Proof},
-    }%
+      \renewcommand{\captionfont}{\五号} %表题,图题用五号宋体加黑
+      \captionsetup[table]{labelsep=period, labelfont=bf}
+      \captionsetup[figure]{labelsep=period, labelfont=bf}
+    \ctexset{figurename = {Figure}, tablename  = {Table},}%
   \fi
-  \captionsetup[subfigure]{labelformat=rightBracket, labelsep=enspace}% 子图a,b,c外没有括号
 
 % 设定浮动体内字体大小
 \RequirePackage{floatrow}
@@ -231,14 +222,15 @@
 % 定义中英文常量
 \ifsustech@chinese
   \def\contentsname{目录}%
-  \def\bibname{参考文献}%
+  \def\bibtitle{参考文献}%
   \def\appendixname{附录}%
   \def\sustech@acknowledgement@name{致谢}%
   \def\sustech@abstract@name{摘要}%
   \def\sustech@honesty@name{诚信承诺书}%
 \else
-  \def\contentsname{Table of Content}%
-  \def\bibname{References}%
+  \def\contentsname{Contents}%
+  % 用bibname这个变量会被莫名其妙覆盖，改成bibtitle
+  \def\bibtitle{References}%
   \def\appendixname{Appendix}%
   \def\sustech@acknowledgement@name{Acknowledgement}%
   \def\sustech@abstract@name{Abstract}%
@@ -434,14 +426,6 @@
   \end{spacing}
   \clearpage\restoregeometry
 }
-\newcommand\诚信承诺书{
-  \pdfbookmark[1]{\sustech@honesty@name}{coh}
-  \ifsustech@chinese
-    \中文诚信承诺书
-  \else
-    \英文诚信承诺书
-  \fi
-}
 % 摘要
 \RequirePackage{listofitems}
 \newcommand\摘要标题{
@@ -453,13 +437,16 @@
       \黑体\二号\题目@英
     \fi
     \\
-    \ifdefempty{\副标题@中}%
+    
+    \ifsustech@chinese
+      %  英文论文一般没有副标题
+      \ifdefempty{\副标题@中}%
       {% empty
         \relax
       }{% not empty
         \hspace*{\fill} \小二 ——\副标题@中\\
       }%
-    \ifsustech@chinese
+
       \vskip 1cm
       \宋体\四号\姓名@中 \\[9pt]
       （\楷书\小四{\系别@中 \quad 指导教师： \指导老师@中}）
@@ -503,9 +490,9 @@
 \newcommand{\参考文献}{
   % 或者可以将refname置空, 按照附录的样式修改.
   \phantomsection
-  \addcontentsline{toc}{section}{\bibname}
-  \sectionmark{\bibname}
-  \section*{\centerline{\bibname}}
+  \addcontentsline{toc}{section}{\bibtitle}
+  \sectionmark{\bibtitle}
+  \section*{\centerline{\bibtitle}}
 }
 \ifsustech@chinese
   \AtBeginDocument{%
@@ -570,6 +557,11 @@
   \hypersetup{
     pdfcreator={\sustechthesis-v\version}}
 }%
+
+% 修正英文环境下 Proof 命令显示中文的问题
+\ifsustech@english
+  \renewcommand{\proofname}{Proof} 
+\fi
 
 \endinput
 %%


### PR DESCRIPTION
1. 更改英文环境下的表、图引用格式，基本与 ACM Reference 风格一致。
2. 修复英文环境下参考文献页标题始终显示为"Bibliography"的问题
3. 修复英文环境下Proof命令显示中文"证明"的问题
4. 修复英文环境下显示中文副标题的问题
5. 新增英文示例